### PR TITLE
Docker build and Google Container Builder config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-FROM alpine:3.5
+FROM golang:1.10 as build
+WORKDIR /go/src/app
+ADD . /go/src/app
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+RUN dep ensure
+RUN go install .
 
-ADD deploy/files/nsync /root
-
-ENTRYPOINT ["/root/nsync"]
+FROM gcr.io/distroless/base
+COPY --from=build /go/bin/app /
+ENTRYPOINT ["/app"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,4 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/nsync', '.']
+images: ['gcr.io/$PROJECT_ID/nsync']


### PR DESCRIPTION
This adds containerized build to the Dockerfile, use of [distroless](https://github.com/GoogleContainerTools/distroless) for the resulting image.

I also added a config file for [container builder](https://cloud.google.com/container-builder/) for good measure.